### PR TITLE
Add CpE advising page

### DIFF
--- a/bacs.md
+++ b/bacs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: BACS Information
-nav_order: 3
+nav_order: 3.2
 has_children: true
 ---
 

--- a/bscs.md
+++ b/bscs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: BSCS Information
-nav_order: 2
+nav_order: 3.1
 ---
 
 # BSCS Information

--- a/cpe.md
+++ b/cpe.md
@@ -1,0 +1,158 @@
+---
+layout: default
+title: CpE Information
+nav_order: 3.3
+---
+
+# Computer Engineering Information
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## Overview
+
+Faculty from the Computer Science and Electrical & Computer Engineering
+Departments jointly administer the CpE undergraduate degree program. The
+curriculum has been carefully designed to assure that students obtain an
+excellent background in both disciplines.
+
+What does a Computer Engineer do? We work with hardware and software to create
+modern computing and embedded systems. Graduates of the Bachelors of Science in
+Computer Engineering Program are successful practitioners and innovators in
+computer engineering and other fields. Our students learn to analyze, design and
+implement creative solutions to problems with computer hardware, software,
+systems and applications. They contribute effectively as team members,
+communicate clearly and interact responsibly with colleagues, clients, employers
+and society.
+
+
+## Undergraduate Record
+
+The official undergraduate record contains the official rules for completing the
+degree program. If there is any disagreement between these pages and the rules
+in the undergraduate record, the record is the final authority.
+
+[UVA CpE Undergraduate Record 2022-2023](http://records.ureg.virginia.edu/preview_program.php?catoid=54&poid=7138)
+
+
+## Declaring the Major
+
+Students declare their major in the School of Engineering and Applied Science
+either in their second semester if they entered the school as a first year
+student or upon transfer to the School. More information can be found on the
+[SEAS page for major declaration](http://records.ureg.virginia.edu/content.php?catoid=54&navoid=4326#Major_Minor).
+
+
+## Degree Requirements
+
+All students completing the Bachelor of Science degree in Computer Engineering
+must fulfill the following requirements.
+
+### School of Engineering and Applied Science General Requirements
+
+CpE students must complete the unified set of general requirements for all
+engineering majors. More information can be found on the SEAS Curricular
+Requirements page. These courses are often completed during the first two years
+in SEAS, with the exception of STS 4500 and 4600, which are taken during the
+fall and spring of the fourth year, respectively.
+
+*   [APMA 1110 - Single Variable Calculus II](https://louslist.org/CC/APMA.html) (Credits: 4)
+*   [APMA 2120 - Multivariable Calculus III](https://louslist.org/CC/APMA.html) (Credits: 4)
+*   [CHEM 1410/1411 - Introductory Chemistry I & Lab](https://louslist.org/CC/Chemistry.html) (Credits: 4)
+*   [CS 1110/1111/1112/1113 - Introduction to Programming](/courses.html#cs-1110-introduction-to-programming) (Credits: 3) (more info below)
+*   [ENGR 1624 - Introduction to Engineering](https://louslist.org/CC/ENGR.html)
+*   [PHYS 1425/1429 - Introductory Physics I & Lab](https://louslist.org/CC/Physics.html) (Credits: 4)
+*   ECE 2200 - Applied Physics: Electricity and Magnetism or [PHYS 2415/2419 - Introductory Physics II & Lab](https://louslist.org/CC/Physics.html) (Credits: 4)
+*   [STS 1500 - Science, Technology, and Contemporary Issues](https://louslist.org/CC/STS.html) (Credits: 3)
+*   [STS 2000 or 3000 level - STS Elective](https://louslist.org/CC/STS.html) (Credits: 3) (see Department of Engineering and Society for more information)
+*   [STS 4500 - STS and Engineering Practice](https://louslist.org/CC/STS.html) (Credits: 3)
+*   [STS 4600 - The Engineer, Ethics, and Professional Responsibility](https://louslist.org/CC/STS.html) (Credits: 3)
+*   [Math and Science Elective](https://engineering.virginia.edu/current-students/current-undergraduate-students/degree-information/elective-information) (Credits: 3)
+*   [Humanities or Social Science Electives](https://engineering.virginia.edu/current-students/current-undergraduate-students/degree-information/elective-information) (Credits: 9)
+
+### Introduction to Programming
+
+All SEAS students (including CpE majors) must complete one Introduction to
+Programming course as a part of their general SEAS requirements.
+[More information on CS 111X options](/bscs.html#introduction-to-programming).
+
+### Core Curriculum
+
+The core of the computer engineering program provides depth in the areas of ECE
+fundamentals, software engineering, digital logic, embedded systems and computer
+systems.
+
+#### Before Spring 2023
+
+* CS 2100 - Data Structures and Algorithms 1 (Credits: 3)
+* CS 2120 - Discrete Math and Theory 1 (Credits: 3)
+* CS 2130 - Computer Systems and Organization 1 (Credits: 4)
+* CS 3130 - Computer Systems and Organization 2 (Credits: 4)
+* CS 3140 - Software Development Essentials (Credits: 3)
+* ECE 2330 - Digital Logic and Design (Credits: 3)
+* ECE 2630 - ECE Fundamentals I (Credits: 4)
+* ECE 2660 - ECE Fundamentals II (Credits: 4)
+* ECE 3430 - Intro Embedded Computing Systems (Credits: 4)
+* ECE 3750 - ECE Fundamentals III (Credits: 4)
+* ECE 4435 - Computer Architecture & Design (Credits: 4.5)
+
+Total: 40.5 credits.
+
+#### After Spring 2023
+
+* CS 2100 - Data Structures and Algorithms 1 (Credits: 3)
+* CS 2120 - Discrete Math and Theory 1 (Credits: 3)
+* CS 2130 - Computer Systems and Organization 1 (Credits: 4)
+* CS 3130 - Computer Systems and Organization 2 (Credits: 4)
+* CS 3140 - Software Development Essentials (Credits: 3)
+* ECE 2200 - Applied Circuits (Credits: 3)
+* ECE 2330 - Digital Logic and Design (Credits: 3)
+* ECE 2600 - Electronics (Credits: 3)
+* ECE 2700 - Signals and Systems (Credits: 3)
+* ECE 3430 - Intro Embedded Computing Systems (Credits: 4)
+* ECE 4435 - Computer Architecture & Design (Credits: 4.5)
+
+Total: 37.5 credits.
+
+### CS/ECE Electives
+
+CS/ECE electives are CS or ECE courses at the 3000 level or
+higher. Two of the CS/ECE electives must be 4000 level or above.
+
+#### Before Spring 2023
+
+CpE majors must complete 12 credits of CS/ECE electives.
+
+#### After Spring 2023
+
+CpE majors must complete 15 credits of CS/ECE electives.
+
+### Capstone
+
+CpE majors must take ECE 4440 to fulfill the capstone requirement.
+
+- ECE 4440 - Embedded System Design (Credits: 4.5)
+
+### Science/Math Elective
+
+Chosen from: BIOL 2100, 2200; CHEM 1420; approved APMA course; MSE 2090; and
+PHYS 2620.
+
+### STS Elective
+
+Any course which meets the Second Writing Requirement as specified in the
+College of Arts & Sciences (CLAS) may be substituted for STS 2XXX/3XXX.
+
+### Unrestricted Electives
+
+CpE majors must complete twelve (12) credits of unrestricted electives.
+APMA 1090 counts as three-credit unrestricted elective. Other unrestricted
+electives may be chosen from any graded course in the University except the
+following mathematics courses: MATH 1310, STAT 1100 and STAT 1120 or any course
+that substantially duplicate any others offered for the degree including PHYS
+2010, 2020; CS 1010, 1020; or any introductory programming course. Students in
+doubt as to what is acceptable to satisfy a degree requirement should get the
+approval of their advisor and the dean's office, located A122 Thornton Hall.
+[See the SEAS page regarding electives for more
+information.](https://engineering.virginia.edu/current-students/current-undergraduate-students/degree-information/elective-information)

--- a/minor.md
+++ b/minor.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: CS Minor
-nav_order: 4
+nav_order: 3.4
 ---
 
 # CS Minor


### PR DESCRIPTION
This is distilled from 

- https://newadvising.uvacs.org/bscs.html
- https://engineering.virginia.edu/computer-engineering-program/computer-engineering-undergraduate-program
- http://records.ureg.virginia.edu/preview_program.php?catoid=54&poid=7138

I found that decimals in page ordering work, not sure if that is how you wanted to go.